### PR TITLE
json_int_t should be used (Capital I) for time

### DIFF
--- a/org.inaetics.demonstrator.celix.implementation/queue_endpoint/private/src/queue_endpoint_impl.c
+++ b/org.inaetics.demonstrator.celix.implementation/queue_endpoint/private/src/queue_endpoint_impl.c
@@ -211,7 +211,7 @@ celix_status_t queueEndpoint_take(remote_endpoint_pt endpoint, char *data, char 
 		int result = service->take(service->sampleQueue, workSample);
 
 		if (result == 0) {
-			resultRoot = json_pack("{s:{s:i, s:f, s:f}}", "r", "sampleTime", workSample->time, "value1", workSample->value1, "value2", workSample->value2);
+			resultRoot = json_pack("{s:{s:I, s:f, s:f}}", "r", "sampleTime", workSample->time, "value1", workSample->value1, "value2", workSample->value2);
 		}
 		else
 		{

--- a/org.inaetics.demonstrator.celix.implementation/queue_proxy/private/src/queue_proxy_impl.c
+++ b/org.inaetics.demonstrator.celix.implementation/queue_proxy/private/src/queue_proxy_impl.c
@@ -159,7 +159,7 @@ int queueProxy_take(void* queue, struct sample *sample) {
 				else if (json_is_null(js_sample)) {
 					status = CELIX_BUNDLE_EXCEPTION;
 				}
-				else if (json_unpack(js_sample, "{s:i,s:f,s:f}", "sampleTime", &sample->time, "value1", &sample->value1, "value1", &sample->value2) != 0) {
+				else if (json_unpack(js_sample, "{s:I,s:f,s:f}", "sampleTime", &sample->time, "value1", &sample->value1, "value1", &sample->value2) != 0) {
 	                printf("QUEUE_PROXY: take: got error while json_unpack for '%s'\n", json_dumps(js_sample, JSON_DECODE_ANY));
 					status = CELIX_BUNDLE_EXCEPTION;
 				}


### PR DESCRIPTION
On Android using the small i (regular json int) doesn't work.

API Reference about json_int_t from Jansson:
"This is the C type that is used to store JSON integer values. It represents the widest integer type available on your system. In practice it’s just a typedef of long long if your compiler supports it, otherwise long.
Usually, you can safely use plain int in place of json_int_t, and the implicit C integer conversion handles the rest. Only when you know that you need the full 64-bit range, you should use json_int_t explicitly."

The time (uint64_t) probably uses the full 64-bit range.
